### PR TITLE
Fix unchanging variant components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ab-experiment",
-  "version": "1.2.9",
+  "version": "1.3",
   "description": "AB Experiment React Component",
   "main": "lib/index.js",
   "repository": "git@github.com:envato/react-ab-experiment.git",

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,6 @@ class Experiment extends React.Component {
       loading: true,
       variantName: null
     }
-
-    this.experimentId = this.props.id
-    this.experimentKey = `experiment_${this.experimentId}`
   }
 
   nullCache () {
@@ -29,7 +26,7 @@ class Experiment extends React.Component {
   }
 
   fetchVariantName() {
-    return this.props.fetchVariantName && this.props.fetchVariantName(this.experimentId)
+    return this.props.fetchVariantName && this.props.fetchVariantName(this.props.experimentId)
   }
 
   chooseRandomVariantName () {
@@ -39,11 +36,13 @@ class Experiment extends React.Component {
   }
 
   getVariantName () {
-    let variantName = this.cache().get(this.experimentKey)
+    const experimentKey = `experiment_${this.props.experimentId}`
+    const variantName = this.cache().get(experimentKey)
+
     if (variantName == null) {
       return (this.fetchVariantName() || this.chooseRandomVariantName()).then((variantName) => {
-        this.props.onEnrolment(this.experimentId, variantName)
-        this.cache().set(this.experimentKey, variantName)
+        this.props.onEnrolment(this.props.experimentId, variantName)
+        this.cache().set(experimentKey, variantName)
         return variantName
       }).catch((err) => {
         const originalVariant = this.props.children[0]
@@ -70,7 +69,7 @@ class Experiment extends React.Component {
 }
 
 Experiment.propTypes = {
-  id:               PropTypes.string.isRequired,
+  experimentId:     PropTypes.string.isRequired,
   onEnrolment:      PropTypes.func.isRequired,
   fetchVariantName: PropTypes.func,
   cache:            PropTypes.shape({

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,11 @@ class Experiment extends React.Component {
     super(props)
     this.state = {
       loading: true,
-      variant: null
+      variantName: null
     }
 
     this.experimentId = this.props.id
     this.experimentKey = `experiment_${this.experimentId}`
-    this.variantComponents = this.props.children
   }
 
   nullCache () {
@@ -34,8 +33,8 @@ class Experiment extends React.Component {
   }
 
   chooseRandomVariantName () {
-    const randomIndex = Math.floor(Math.random() * (this.variantComponents.length))
-    const choosenVariantComponent = this.variantComponents[randomIndex]
+    const randomIndex = Math.floor(Math.random() * (this.props.children.length))
+    const choosenVariantComponent = this.props.children[randomIndex]
     return Promise.resolve(choosenVariantComponent.props.name)
   }
 
@@ -47,7 +46,7 @@ class Experiment extends React.Component {
         this.cache().set(this.experimentKey, variantName)
         return variantName
       }).catch((err) => {
-        const originalVariant = this.variantComponents[0]
+        const originalVariant = this.props.children[0]
         return originalVariant.props.name
       })
     } else {
@@ -57,16 +56,16 @@ class Experiment extends React.Component {
 
   componentDidMount () {
     this.getVariantName().then((variantName) => {
-      const variant = this.variantComponents.find(variant => variant.props.name == variantName)
-      this.setState({
-        loading: false,
-        variant: variant
-      })
+      this.setState({ loading: false, variantName: variantName })
     })
   }
 
+  findVariantByName(name) {
+    return this.props.children.find(v => v.props.name == name) || null
+  }
+
   render () {
-    return this.state.variant
+    return this.findVariantByName(this.state.variantName)
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ class Experiment extends React.Component {
     const experimentKey = `experiment_${this.props.experimentId}`
     const variantName = this.cache().get(experimentKey)
 
-    if (variantName == null) {
+    if (!variantName) {
       return (this.fetchVariantName() || this.chooseRandomVariantName()).then((variantName) => {
         this.props.onEnrolment(this.props.experimentId, variantName)
         this.cache().set(experimentKey, variantName)


### PR DESCRIPTION
When the props/state of a variant component(s) wrapped into `Experiment` are changed, the Experiment component should re-render to display the updated component(s).

In the current implementation the variant component(s) gets "cached" on mount, and is never updated even if its props/state change.

This PR fixes this issue.

### How it's fixed

- Memorise `variant name` in state instead of actual `variant component`.
- Find the Variant to render by its name, so if the state or props of the Variant have been changed, the Experiment component could find updated component and re-render it.

### Example

1. Old behaviour: `Experiment` wraps item list. Item list is not updated when user does a new search.
![wrong-ab-testing-library-behaviour](https://user-images.githubusercontent.com/576088/33915557-1eb43c02-dff8-11e7-8dcf-01f4de5e2814.gif)

2. Fixed behaviour. `Experiment` wraps item list. Item list is updated when user does a new search.
![fixed-ab-testing](https://user-images.githubusercontent.com/576088/33915701-dc7cd5fa-dff8-11e7-9521-25dffcc3d7df.gif)

